### PR TITLE
Use mod.conf for name/dependencies

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-default
-moreblocks
-unifieddyes

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,2 @@
+name = stained_glass
+depends = default, moreblocks, unifieddyes


### PR DESCRIPTION
Deletes deprecated `depends.txt`.